### PR TITLE
Added wrappers to additional CPX functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ To use the built in Benders Decomposition in CPLEX, do the following:
 1) Create a direct model in JuMP: `model = JuMP.direct_model(CPLEX.Optimizer())`. This allows the varialbes form your JuMP model to map to the CPLEX inner model.
 2) Access the inner model: `model_inner = JuMP.backend(model).inner`
 3) Create a new annotation (https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.cplex.help/refcallablelibrary/cpxapi/newlongannotation.html): `newlongannotation(model_inner, "cpxBendersPartition", Int32(0))`
-4) Annotate your model using the wrapped function `setlongannotations` (https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.cplex.help/refcallablelibrary/cpxapi/setlongannotations.html).
+4) Annotate your model using the wrapped function `setlongannotations` (https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.cplex.help/refcallablelibrary/cpxapi/setlongannotations.html). NOTE: See example below to avoid issues with setlongannotations.
 5) Set the `CPXPARAM_Benders_Strategy` using `MOI.RawParameter` as described in the previous section. For annotated models use either strategy 0, 1, or 2 (see CPLEX documentation). If you don't want to provide CPLEX with annotations, it can do the decomposition automatically by using strategy 3. If you take the automatic route, then ignore steps 1-4.
 
 ## Example

--- a/README.md
+++ b/README.md
@@ -60,3 +60,12 @@ set_optimizer_attribute(model, "CPX_PARAM_EPINT", 1e-8)
 ```
 
 Parameters match those of the C API in the [CPLEX documentation](https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.cplex.help/CPLEX/Parameters/topics/introListAlpha.html).
+
+## Annotating a model for Benders Decomposition
+
+To use the built in Benders Decomposition in CPLEX, do the following:
+1) Create a direct model in JuMP: `model = JuMP.direct_model(CPLEX.Optimizer())`
+2) Access the inner model: `model_inner = JuMP.backend(model).inner`
+3) Create a new annotation (https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.cplex.help/refcallablelibrary/cpxapi/newlongannotation.html): `newlongannotation(model_inner, "cpxBendersPartition", Int32(0))`
+4) Annotate your model using the wrapped function `setlongannotations` (https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.cplex.help/refcallablelibrary/cpxapi/setlongannotations.html).
+5) Set the `CPXPARAM_Benders_Strategy` using `MOI.RawParameter` as described in the previous section. For annotated models use either strategy 0, 1, or 2 (see CPLEX documentation). If you don't want to provide CPLEX with annotations, it can do the decomposition automatically by using strategy 3. If you take the automatic route, then ignore steps 1-4.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Parameters match those of the C API in the [CPLEX documentation](https://www.ibm
 ## Annotating a model for Benders Decomposition
 
 To use the built in Benders Decomposition in CPLEX, do the following:
-1) Create a direct model in JuMP: `model = JuMP.direct_model(CPLEX.Optimizer())`
+1) Create a direct model in JuMP: `model = JuMP.direct_model(CPLEX.Optimizer())`. This allows the varialbes form your JuMP model to map to the CPLEX inner model.
 2) Access the inner model: `model_inner = JuMP.backend(model).inner`
 3) Create a new annotation (https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.cplex.help/refcallablelibrary/cpxapi/newlongannotation.html): `newlongannotation(model_inner, "cpxBendersPartition", Int32(0))`
 4) Annotate your model using the wrapped function `setlongannotations` (https://www.ibm.com/support/knowledgecenter/SSSA5P_12.9.0/ilog.odms.cplex.help/refcallablelibrary/cpxapi/setlongannotations.html).

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ To use the built in Benders Decomposition in CPLEX, do the following:
 5) Set the `CPXPARAM_Benders_Strategy` using `MOI.RawParameter` as described in the previous section. For annotated models use either strategy 0, 1, or 2 (see CPLEX documentation). If you don't want to provide CPLEX with annotations, it can do the decomposition automatically by using strategy 3. If you take the automatic route, then ignore steps 1-4.
 
 ## Example
-
+```Julia
 using JuMP, MathOptInterface, CPLEX
 const MOI = MathOptInterface
 #=
@@ -144,3 +144,4 @@ MOI.set(m, MOI.RawParameter("CPXPARAM_Benders_Strategy"), benders_strategy)
 MOI.set(m, MOI.RawParameter("CPXPARAM_Preprocessing_Presolve"), 0)
 #Optimize model
 optimize!(m)
+```

--- a/src/cpx_solve.jl
+++ b/src/cpx_solve.jl
@@ -145,9 +145,7 @@ function getobj(model::Model,begin_range::Cint,end_range::Cint)
                 Cint,
                 Cint),
                 model.env.ptr, model.lp, obj, begin_range, end_range)
-    if stat != 0
-        throw(CplexError(model.env, stat))
-    end
+    stat == 0 || throw(CplexError(model.env, stat))
     return obj
 end
 

--- a/src/cpx_solve.jl
+++ b/src/cpx_solve.jl
@@ -48,7 +48,6 @@ function set_branching_priority(model::Model, indices::Vector{Cint}, priority::V
     return nothing
 end
 
-
 function newlongannotation(model::Model, name::String, defval::Clong)
     stat = @cpx_ccall(newlongannotation, Cint, (
                       Ptr{Cvoid},
@@ -108,6 +107,16 @@ function writebendersannotation(model::Model, filename::String)
     return nothing
 end
 
+function readcopyannotations(model::Model, filename::String)
+    stat = @cpx_ccall(readcopyannotations, Cint, (
+                Ptr{Cvoid},
+                Ptr{Cvoid},
+                Ptr{Cchar}),
+                model.env.ptr, model.lp, filename)
+    stat == 0 || throw(CplexError(model.env, stat))
+    return nothing
+end
+
 function getcolindex(model::Model, name::String)
     index_p = Ref{Cint}()
     stat = @cpx_ccall(getcolindex, Cint, (
@@ -157,7 +166,8 @@ function getobjsen(model::Model)
     return objsen
 end
 
-export setlongannotations, newlongannotation, writeannotations, writebendersannotation, getlongannotationindex
+export setlongannotations, newlongannotation, getlongannotationindex
+export writeannotations, writebendersannotation, readcopyannotations
 export getnumcols, getnumrows, getobj, getobjsen, getcolindex
 
 function c_api_getobjval(model::Model)

--- a/src/cpx_solve.jl
+++ b/src/cpx_solve.jl
@@ -145,30 +145,9 @@ function getnumrows(model::Model)
     return numrows
 end
 
-function getobj(model::Model,begin_range::Cint,end_range::Cint)
-    obj = Vector{Cdouble}(undef, 1)
-    stat = @cpx_ccall(getobj, Cint, (
-                Ptr{Cvoid},
-                Ptr{Cvoid},
-                Ptr{Cdouble},
-                Cint,
-                Cint),
-                model.env.ptr, model.lp, obj, begin_range, end_range)
-    stat == 0 || throw(CplexError(model.env, stat))
-    return obj
-end
-
-function getobjsen(model::Model)
-    objsen = @cpx_ccall(getobjsen, Cint, (
-                Ptr{Cvoid},
-                Ptr{Cvoid}),
-                model.env.ptr, model.lp)
-    return objsen
-end
-
 export setlongannotations, newlongannotation, getlongannotationindex
 export writeannotations, writebendersannotation, readcopyannotations
-export getnumcols, getnumrows, getobj, getobjsen, getcolindex
+export getnumcols, getnumrows, getcolindex
 
 function c_api_getobjval(model::Model)
   objval = Vector{Cdouble}(undef, 1)

--- a/src/cpx_solve.jl
+++ b/src/cpx_solve.jl
@@ -76,7 +76,91 @@ function setlongannotations(model::Model, idx::Cint, objtype::Cint, cnt::Cint, i
     return nothing
 end
 
-export setlongannotations, newlongannotation
+function getlongannotationindex(model::Model, name::String)
+    index_p = Ref{Cint}()
+    stat = @cpx_ccall(getlongannotationindex, Cint, (
+                Ptr{Cvoid},
+                Ptr{Cvoid},
+                Ptr{Cchar},
+                Ptr{Cint}),
+                model.env.ptr, model.lp, name, index_p)
+    stat == 0 || throw(CplexError(model.env, stat))
+    return index_p[]
+end
+
+function writeannotations(model::Model, filename::String)
+    stat = @cpx_ccall(writeannotations, Cint, (
+                Ptr{Cvoid},
+                Ptr{Cvoid},
+                Ptr{Cchar}),
+                model.env.ptr, model.lp, filename)
+    stat == 0 || throw(CplexError(model.env, stat))
+    return nothing
+end
+
+function writebendersannotation(model::Model, filename::String)
+    stat = @cpx_ccall(writebendersannotation, Cint, (
+                Ptr{Cvoid},
+                Ptr{Cvoid},
+                Ptr{Cchar}),
+                model.env.ptr, model.lp, filename)
+    stat == 0 || throw(CplexError(model.env, stat))
+    return nothing
+end
+
+function getcolindex(model::Model, name::String)
+    index_p = Ref{Cint}()
+    stat = @cpx_ccall(getcolindex, Cint, (
+                Ptr{Cvoid},
+                Ptr{Cvoid},
+                Ptr{Cchar},
+                Ptr{Cint}),
+                model.env.ptr, model.lp, name, index_p)
+    stat == 0 || throw(CplexError(model.env, stat))
+    return index_p[]
+end
+
+function getnumcols(model::Model)
+    numcols = @cpx_ccall(getnumcols, Cint, (
+                Ptr{Cvoid},
+                Ptr{Cvoid}),
+                model.env.ptr, model.lp)
+    return numcols
+end
+
+function getnumrows(model::Model)
+    numrows = @cpx_ccall(getnumrows, Cint, (
+                Ptr{Cvoid},
+                Ptr{Cvoid}),
+                model.env.ptr, model.lp)
+    return numrows
+end
+
+function getobj(model::Model,begin_range::Cint,end_range::Cint)
+    obj = Vector{Cdouble}(undef, 1)
+    stat = @cpx_ccall(getobj, Cint, (
+                Ptr{Cvoid},
+                Ptr{Cvoid},
+                Ptr{Cdouble},
+                Cint,
+                Cint),
+                model.env.ptr, model.lp, obj, begin_range, end_range)
+    if stat != 0
+        throw(CplexError(model.env, stat))
+    end
+    return obj
+end
+
+function getobjsen(model::Model)
+    objsen = @cpx_ccall(getobjsen, Cint, (
+                Ptr{Cvoid},
+                Ptr{Cvoid}),
+                model.env.ptr, model.lp)
+    return objsen
+end
+
+export setlongannotations, newlongannotation, writeannotations, writebendersannotation, getlongannotationindex
+export getnumcols, getnumrows, getobj, getobjsen, getcolindex
 
 function c_api_getobjval(model::Model)
   objval = Vector{Cdouble}(undef, 1)


### PR DESCRIPTION
CPX functions added are pertinent to model annotations and querying models.

New wrappers added: writeannotations, writebendersannotation, getlongannotationindex, getnumcols, getnumrows, getobj, getobjsen, getcolindex.