### PR TITLE
Round bounds for ZeroOne variables to avoid CPLEX warning

### DIFF
--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -1448,9 +1448,9 @@ function MOI.add_constraint(
         CPXchgbds(
             model.env, model.lp, 2, Cint[col, col], Cchar['L', 'U'], [0.0, 1.0]
         )
-    elseif info.bound == _LESS_THAN
-        CPXchgbds(model.env, model.lp, 1, p_col, Ref{Cchar}('U'), Ref(1.0))
     elseif info.bound == _GREATER_THAN
+        CPXchgbds(model.env, model.lp, 1, p_col, Ref{Cchar}('U'), Ref(1.0))
+    elseif info.bound == _LESS_THAN
         CPXchgbds(model.env, model.lp, 1, p_col, Ref{Cchar}('L'), Ref(0.0))
     else
         Cint(0)

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -450,3 +450,70 @@ end
         @test MOI.get(model, MOI.ConstraintConflictStatus(), c2) == MOI.NOT_IN_CONFLICT
     end
 end
+
+@testset "ZeroOne_NONE" begin
+    model = CPLEX.Optimizer()
+    x = MOI.add_variable(model)
+    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
+    tmp = Ref{Cdouble}()
+    CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == 0.0
+    CPLEX.CPXgetub(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == 1.0
+    MOI.delete(model, c)
+    CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == -CPLEX.CPX_INFBOUND
+    CPLEX.CPXgetub(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == CPLEX.CPX_INFBOUND
+end
+
+@testset "ZeroOne_LESS_THAN" begin
+    model = CPLEX.Optimizer()
+    x = MOI.add_variable(model)
+    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
+    MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(2.0))
+    tmp = Ref{Cdouble}()
+    CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == 0.0
+    CPLEX.CPXgetub(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == 2.0
+    MOI.delete(model, c)
+    CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == -CPLEX.CPX_INFBOUND
+    CPLEX.CPXgetub(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == 2.0
+end
+
+@testset "ZeroOne_GREATER_THAN" begin
+    model = CPLEX.Optimizer()
+    x = MOI.add_variable(model)
+    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
+    MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(-2.0))
+    tmp = Ref{Cdouble}()
+    CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == -2.0
+    CPLEX.CPXgetub(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == 1.0
+    MOI.delete(model, c)
+    CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == -2.0
+    CPLEX.CPXgetub(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == CPLEX.CPX_INFBOUND
+end
+
+@testset "ZeroOne_GREATER_THAN" begin
+    model = CPLEX.Optimizer()
+    x = MOI.add_variable(model)
+    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
+    MOI.add_constraint(model, MOI.SingleVariable(x), MOI.Interval(-2.0, 2.0))
+    tmp = Ref{Cdouble}()
+    CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == -2.0
+    CPLEX.CPXgetub(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == 2.0
+    MOI.delete(model, c)
+    CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == -2.0
+    CPLEX.CPXgetub(model.env, model.lp, tmp, 0, 0)
+    @test tmp[] == 2.0
+end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -479,8 +479,8 @@ end
 function test_ZeroOne_LESS_THAN()
     model = CPLEX.Optimizer()
     x = MOI.add_variable(model)
-    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
     MOI.add_constraint(model, MOI.SingleVariable(x), MOI.LessThan(2.0))
+    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
     tmp = Ref{Cdouble}()
     CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
     @test tmp[] == 0.0
@@ -496,8 +496,8 @@ end
 function test_ZeroOne_GREATER_THAN()
     model = CPLEX.Optimizer()
     x = MOI.add_variable(model)
-    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
     MOI.add_constraint(model, MOI.SingleVariable(x), MOI.GreaterThan(-2.0))
+    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
     tmp = Ref{Cdouble}()
     CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
     @test tmp[] == -2.0
@@ -513,8 +513,8 @@ end
 function test_ZeroOne_GREATER_THAN()
     model = CPLEX.Optimizer()
     x = MOI.add_variable(model)
-    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
     MOI.add_constraint(model, MOI.SingleVariable(x), MOI.Interval(-2.0, 2.0))
+    c = MOI.add_constraint(model, MOI.SingleVariable(x), MOI.ZeroOne())
     tmp = Ref{Cdouble}()
     CPLEX.CPXgetlb(model.env, model.lp, tmp, 0, 0)
     @test tmp[] == -2.0

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -510,7 +510,7 @@ function test_ZeroOne_GREATER_THAN()
     @test tmp[] == CPLEX.CPX_INFBOUND
 end
 
-function test_ZeroOne_GREATER_THAN()
+function test_ZeroOne_INTERVAL()
     model = CPLEX.Optimizer()
     x = MOI.add_variable(model)
     MOI.add_constraint(model, MOI.SingleVariable(x), MOI.Interval(-2.0, 2.0))


### PR DESCRIPTION
Closes #311