### PR TITLE
Allow broadcasting in callbacks

### DIFF
--- a/src/MOI/MOI_callbacks.jl
+++ b/src/MOI/MOI_callbacks.jl
@@ -5,6 +5,7 @@ mutable struct CallbackContext
 end
 Base.cconvert(::Type{Ptr{Cvoid}}, x::CallbackContext) = x
 Base.unsafe_convert(::Type{Ptr{Cvoid}}, x::CallbackContext) = x.ptr::Ptr{Cvoid}
+Base.broadcastable(x::CallbackContext) = Ref(x)
 
 mutable struct _CallbackUserData
     model::Optimizer

--- a/test/MathOptInterface/MOI_callbacks.jl
+++ b/test/MathOptInterface/MOI_callbacks.jl
@@ -482,6 +482,21 @@ function test_InterruptException()
     @test MOI.get(model, MOI.TerminationStatus()) == MOI.INTERRUPTED
 end
 
+function test_CallbackFunction_broadcast()
+    model, x, _ = callback_knapsack_model()
+    f(cb_data, x) = MOI.get(model, MOI.CallbackVariablePrimal(cb_data), x)
+    solutions = Vector{Float64}[]
+    MOI.set(model, CPLEX.CallbackFunction(), (cb_data, cb_where) -> begin
+        if cb_where == CPLEX.CPX_CALLBACKCONTEXT_CANDIDATE
+            CPLEX.load_callback_variable_primal(cb_data, cb_where)
+            push!(solutions, f.(cb_data, x))
+        end
+    end)
+    MOI.optimize!(model)
+    @test length(solutions) > 0
+    @test length(solutions[1]) == length(x)
+end
+
 end  # module TestCallbacks
 
 runtests(TestCallbacks)


### PR DESCRIPTION
Raised on Discourse: https://discourse.julialang.org/t/jump-cplex-retrieve-value-of-array-variables-in-callback/54933/3