### PR TITLE
Provide a more useful error message to user if no CPLEX binary is found. 

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -39,7 +39,7 @@ function get_error_message_if_not_found()
     end
 
     # Create the error message based on the user's system and the best guess.
-    error_beginning = """
+    return """
     Unable to install CPLEX.jl.
 
     The versions of CPLEX supported by CPLEX.jl are:
@@ -54,23 +54,15 @@ function get_error_message_if_not_found()
     correct location if needed):
     
     ```
-    """
-    
-    error_middle = """
     ENV["CPLEX_STUDIO_BINARIES"] = "$(cplex_studio_folder_guessed)"
     import Pkg
     Pkg.add("CPLEX")
     Pkg.build("CPLEX")
-    """
-    
-    error_end = """
     ```
 
     See the CPLEX.jl README at https://github.com/jump-dev/CPLEX.jl for further
     instructions.
     """
-    
-    return error_beginning * error_middle * error_end
 end
 
 function try_local_installation()

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -20,7 +20,7 @@ function get_error_message_if_not_found()
     # Make the best guess for the CPLEX folder, based on the platform.
     cplex_studio_folders = map(["CPLEX_Studio201", "CPLEX_Studio1210"]) do f
         if Sys.iswindows()
-            return "C:\\\\Program Files\\\\$f\\\\cplex\\\\bin\\\\x86-64_win\\\\"
+            return "C:\\\\Program Files\\\\IBM\\\\ILOG\\\\$f\\\\cplex\\\\bin\\\\x64_win64\\\\"
         elseif Sys.isapple()
             return "/Applications/$f/cplex/bin/x86-64_osx/"
         else

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -18,17 +18,14 @@ end
 
 function get_error_message_if_not_found()
     # Make the best guess for the CPLEX folder, based on the platform.
-    cplex_studio_stem_folders = ["CPLEX_Studio201", "CPLEX_Studio1210"]
-    cplex_studio_folders_win = ["C:\\\\Program Files\\\\IBM\\\\ILOG\\\\$f\\\\cplex\\\\bin\\\\x64_win64\\\\" for f in cplex_studio_stem_folders]
-    cplex_studio_folders_mac = ["/Applications/$f/cplex/bin/x86-64_osx/" for f in cplex_studio_stem_folders]
-    cplex_studio_folders_lin = ["/opt/$f/cplex/bin/x86-64_linux/" for f in cplex_studio_stem_folders]
-    
-    cplex_studio_folders = if Sys.iswindows()
-        cplex_studio_folders_win 
-    elseif Sys.isapple()
-        cplex_studio_folders_mac
-    else
-        cplex_studio_folders_lin
+    cplex_studio_folders = map(["CPLEX_Studio201", "CPLEX_Studio1210"]) do f
+        if Sys.iswindows()
+            return "C:\\\\Program Files\\\\$f\\\\cplex\\\\bin\\\\x86-64_win\\\\"
+        elseif Sys.isapple()
+            return "/Applications/$f/cplex/bin/x86-64_osx/"
+        else
+            return "/opt/$f/cplex/bin/x86-64_linux/"
+        end
     end
     
     cplex_studio_folder_guessed = cplex_studio_folders[1] # If none is found, propose the first one, arbitrarily. 

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -20,7 +20,7 @@ function get_error_message_if_not_found()
     # Make the best guess for the CPLEX folder, based on the platform.
     cplex_studio_folders = map(["CPLEX_Studio201", "CPLEX_Studio1210"]) do f
         if Sys.iswindows()
-            return "C:\\\\Program Files\\\\IBM\\\\ILOG\\\\$f\\\\cplex\\\\bin\\\\x64_win64\\\\"
+            return escape_string("C:\\Program Files\\IBM\\ILOG\\$f\\cplex\\bin\\x64_win64\\")
         elseif Sys.isapple()
             return "/Applications/$f/cplex/bin/x86-64_osx/"
         else

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -78,7 +78,7 @@ function try_local_installation()
     end
 
     # Iterate through a series of places where CPLEX could be found: either in
-    # the path (directly the callable library or # the CPLEX executable) or from
+    # the path (directly the callable library or the CPLEX executable) or from
     # an environment variable.
     cpxvers = [
         "1210", "12100",

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -19,7 +19,7 @@ end
 function get_error_message_if_not_found()
     # Make the best guess for the CPLEX folder, based on the platform.
     cplex_studio_stem_folders = ["CPLEX_Studio201", "CPLEX_Studio1210"]
-    cplex_studio_folders_win = ["C:\\\\Program Files\\\\$f\\\\cplex\\\\bin\\\\x86-64_win\\\\" for f in cplex_studio_stem_folders]
+    cplex_studio_folders_win = ["C:\\\\Program Files\\\\IBM\\\\ILOG\\\\$f\\\\cplex\\\\bin\\\\x64_win64\\\\" for f in cplex_studio_stem_folders]
     cplex_studio_folders_mac = ["/Applications/$f/cplex/bin/x86-64_osx/" for f in cplex_studio_stem_folders]
     cplex_studio_folders_lin = ["/opt/$f/cplex/bin/x86-64_linux/" for f in cplex_studio_stem_folders]
     


### PR DESCRIPTION
Instead of displaying a large message that is the same for all platforms, only show the relevant part for the user's platform. Moreover, check if some folder is recognised and propose it if it is. 

Maybe it would be good to indicate if the path that is proposed exists (and the proposed commands should work out of the box) or if the user should check further?