### PR TITLE
Support both CPLX Studio and Enterprise Server

### DIFF
--- a/deps/build.jl
+++ b/deps/build.jl
@@ -90,9 +90,11 @@ function try_local_installation()
             end
         end
         
-        guessed_file = joinpath(possible_path("CPLEX_Studio$v"), name)
-        if isfile(guessed_file)
-            push!(libnames, guessed_file)
+        for product in ["CPLEX_Studio$v", "CPLEX_Enterprise_Server$v/CPLEX_Studio"]
+            guessed_file = joinpath(possible_path(product), name)
+            if isfile(guessed_file)
+                push!(libnames, guessed_file)
+            end
         end
     end
 


### PR DESCRIPTION
By mistake, I downloaded a version of CPLEX Enterprise Server. The difference is that CPLEX Enterprise Server comes with a software server to run CPLEX, but it bundles a complete copy of CPLEX Studio (in a different folder). This PR also looks for the standard Enterprise Server location.