### PR TITLE
Out-of-memory error now is a termination status.

### DIFF
--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -726,6 +726,14 @@ function test_farkas_dual_max_ii()
     @test clb_dual[2] ≈ c_dual atol = 1e-6
 end
 
+function test_fake_status()
+    model = CPLEX.Optimizer()
+    model.ret_optimize = CPLEX.CPXERR_NO_MEMORY
+    @test MOI.get(model, MOI.TerminationStatus()) == MOI.MEMORY_LIMIT
+    @test MOI.get(model, MOI.RawStatusString()) ==
+        "CPLEX Error  1001: Out of memory.\n"
+end
+
 end  # module TestMOIwrapper
 
 runtests(TestMOIwrapper)


### PR DESCRIPTION
PR spawned from issue #361. It is basically the same that was done for Gurobi.jl issue [397](https://github.com/jump-dev/Gurobi.jl/issues/397) and PR [398](https://github.com/jump-dev/Gurobi.jl/pull/398). The tests pass:

[![2021-03-10-12-03-29-1920x1080.png](https://i.postimg.cc/1z5jF22q/2021-03-10-12-03-29-1920x1080.png)](https://postimg.cc/cv2hy9sx)