### PR TITLE
Backport bugfix in CPXcallbackpostheursoln

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CPLEX"
 uuid = "a076750e-1247-5638-91d2-ce28b192dca0"
 repo = "https://github.com/jump-dev/CPLEX.jl"
-version = "0.7.7"
+version = "0.7.8"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/MOI/MOI_callbacks.jl
+++ b/src/MOI/MOI_callbacks.jl
@@ -326,7 +326,7 @@ function MOI.submit(
     end
     ret = CPXcallbackpostheursoln(
         cb.callback_data,
-        Cint(1),
+        Cint(length(variables)),
         Cint[_info(model, var).column - 1 for var in variables],
         values,
         NaN,


### PR DESCRIPTION
Backporting #376 so that it can be released as 0.7.8 for use with JuMP 0.21.