### PR TITLE
performance issues

### DIFF
--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -138,6 +138,9 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
     # parameter.
     silent::Bool
 
+    has_solution::Bool
+    variable_primal::Union{Nothing,Vector{Float64}}
+
     # Helpers to remember what objective is currently stored in the model.
     objective_type::_ObjectiveType
     objective_sense::Union{Nothing,MOI.OptimizationSense}
@@ -233,6 +236,9 @@ mutable struct Optimizer <: MOI.AbstractOptimizer
         model.env = env === nothing ? Env() : env
         MOI.set(model, MOI.RawOptimizerAttribute("CPXPARAM_ScreenOutput"), 1)
         model.silent = false
+        model.has_solution = false
+        model.variable_primal = nothing
+    
         model.variable_info =
             CleverDicts.CleverDict{MOI.VariableIndex,_VariableInfo}()
         model.affine_constraint_info = Dict{Int,_ConstraintInfo}()
@@ -303,6 +309,8 @@ function MOI.empty!(model::Optimizer)
     model.user_cut_callback = nothing
     model.heuristic_callback = nothing
     model.generic_callback = nothing
+    model.has_solution = false
+    model.variable_primal = nothing
     return
 end
 
@@ -629,6 +637,10 @@ The C API requires 0-indexed columns.
 """
 function column(model::Optimizer, x::MOI.VariableIndex)
     return _info(model, x).column
+end
+
+function column(model::Optimizer, x::Vector{MOI.VariableIndex})
+    return [_info(model, xi).column for xi in x]
 end
 
 function MOI.add_variable(model::Optimizer)
@@ -2621,6 +2633,7 @@ function MOI.optimize!(model::Optimizer)
     model.solve_time = time() - start_time
     model.has_primal_certificate = false
     model.has_dual_certificate = false
+    model.has_solution = false
     if MOI.get(model, MOI.PrimalStatus()) == MOI.INFEASIBILITY_CERTIFICATE
         resize!(model.certificate, length(model.variable_info))
         ret = CPXgetray(model.env, model.lp, model.certificate)
@@ -2631,6 +2644,10 @@ function MOI.optimize!(model::Optimizer)
         ret = CPXdualfarkas(model.env, model.lp, model.certificate, C_NULL)
         _check_ret(model, ret)
         model.has_dual_certificate = true
+    end
+    model.variable_primal = nothing
+    if MOI.get(model, MOI.ResultCount()) == 1
+        model.has_solution = true
     end
     return
 end
@@ -2801,21 +2818,34 @@ function MOI.get(model::Optimizer, attr::MOI.DualStatus)
     end
 end
 
+_update_cache(::Optimizer, data::Vector{Float64}, ::Any) = data
+
+function _update_cache(model::Optimizer, ::Nothing, f_p::F) where {F}
+    n = length(model.variable_info)
+    x = zeros(n)
+    ret = f_p(model.env, model.lp, x, 0, n-1)
+    _check_ret(model, ret)
+    return x
+end
+
+_get_cached_solution(model::Optimizer, data::Vector{Float64}, x) = data[column(model, x)]
+
 function MOI.get(
     model::Optimizer,
     attr::MOI.VariablePrimal,
-    x::MOI.VariableIndex,
+    x::Union{MOI.VariableIndex,Vector{MOI.VariableIndex}},
 )
     _throw_if_optimize_in_progress(model, attr)
     MOI.check_result_index_bounds(model, attr)
-    col = Cint(column(model, x) - 1)
     if model.has_primal_certificate
-        return model.certificate[col+1]
+        return model.certificate[column(model, x)]
     end
-    x = Ref{Cdouble}()
-    ret = CPXgetx(model.env, model.lp, x, col, col)
-    _check_ret(model, ret)
-    return x[]
+    model.variable_primal = _update_cache(
+        model,
+        model.variable_primal,
+        CPXgetx,
+        )
+    return _get_cached_solution(model, model.variable_primal, x)
 end
 
 function MOI.get(


### PR DESCRIPTION
Caching CPLEX primal solution to avoid repeated calls to CPXgetx
(largely inspired from what was done on Cbc)

Should fix https://github.com/jump-dev/CPLEX.jl/issues/371

**Before**
```
julia> optimize(Model(CPLEX.Optimizer))
 11.440209 seconds (1.20 M allocations: 22.125 MiB)
2-dimensional DenseAxisArray{Float64,2,...} with index sets:
    Dimension 1, ["a", "b", "c", "d", "e"]
    Dimension 2, Base.OneTo(20000)
```

**After**
```
julia> optimize(Model(CPLEX.Optimizer))
  0.155641 seconds (1.20 M allocations: 22.888 MiB)
2-dimensional DenseAxisArray{Float64,2,...} with index sets:
    Dimension 1, ["a", "b", "c", "d", "e"]
    Dimension 2, Base.OneTo(20000)
```

**Script**
```
using Distributed
using JuMP
using CPLEX
using Profile
function optimize(model)
	NV = 20000
	set = ["a", "b", "c", "d", "e"]
	@variable(model, var[set, 1:NV], lower_bound=0)
	cost = AffExpr(0.0)
	for s in set
		for t in 1:NV
			add_to_expression!(cost, t* var[s, t])
		end
	end
	@objective(model, Min, cost)
	@constraint(model, [s in set, t = 1:NV], var[s, t] >= t)
	set_silent(model)
	optimize!(model)
	@time begin
		value.(var)
	end
end
optimize(Model(CPLEX.Optimizer))
```