### PR TITLE
Fix typo in get for RawOptimizerAttribute

### DIFF
--- a/src/MOI/MOI_wrapper.jl
+++ b/src/MOI/MOI_wrapper.jl
@@ -470,7 +470,7 @@ function MOI.get(model::Optimizer, param::MOI.RawOptimizerAttribute)
     else
         @assert typeP[] == CPX_PARAMTYPE_LONG
         valueP = Ref{CPXLONG}()
-        ret = CPXsetlongparam(model.env, numP[], valueP)
+        ret = CPXgetlongparam(model.env, numP[], valueP)
         _check_ret(model.env, ret)
         return valueP[]
     end

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -198,6 +198,14 @@ function test_fake_status()
     return
 end
 
+function test_getlongparam()
+    model = CPLEX.Optimizer()
+    y = MOI.get(model, MOI.RawOptimizerAttribute("CPX_PARAM_INTSOLLIM")
+    # The default is a really big number, but not the typemax.
+    @test y > 0.95 * typemax(y)
+    return
+end
+
 end  # module TestMOIwrapper
 
 TestMOIwrapper.runtests()

--- a/test/MathOptInterface/MOI_wrapper.jl
+++ b/test/MathOptInterface/MOI_wrapper.jl
@@ -200,7 +200,7 @@ end
 
 function test_getlongparam()
     model = CPLEX.Optimizer()
-    y = MOI.get(model, MOI.RawOptimizerAttribute("CPX_PARAM_INTSOLLIM")
+    y = MOI.get(model, MOI.RawOptimizerAttribute("CPX_PARAM_INTSOLLIM"))
     # The default is a really big number, but not the typemax.
     @test y > 0.95 * typemax(y)
     return


### PR DESCRIPTION
Found by https://discourse.julialang.org/t/jump-cplex-attribute-error-for-getting-cpx-param-intsollim/77595