### PR TITLE
Add support for v22.1.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "CPLEX"
 uuid = "a076750e-1247-5638-91d2-ce28b192dca0"
 repo = "https://github.com/jump-dev/CPLEX.jl"
-version = "0.9.4"
+version = "0.9.5"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"

--- a/src/CPLEX.jl
+++ b/src/CPLEX.jl
@@ -35,7 +35,7 @@ if _CPLEX_VERSION == v"12.10.0"
 elseif _CPLEX_VERSION == v"20.1.0"
     include("gen2010/libcpx_common.jl")
     include("gen2010/libcpx_api.jl")
-elseif _CPLEX_VERSION == v"22.1.0"
+elseif _CPLEX_VERSION in (v"22.1.0", v"22.1.1")
     include("gen2210/ctypes.jl")
     include("gen2210/libcpx_common.jl")
     include("gen2210/libcpx_api.jl")


### PR DESCRIPTION
I don't have 22.1.1 installed so I didn't test, but the changelog is very sparse: https://www.ibm.com/docs/en/icos/22.1.1?topic=2211-release-notes-cplex, so I assume that this will work.

Closes #415 
