### PR TITLE
Add support for v22.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Free CPLEX licenses are available for [academics and students](http://ibm.biz/Bd
 
 ## Installation
 
-CPLEX.jl requires CPLEX version 12.10, 20.1, or 22.1.
+CPLEX.jl requires CPLEX version 12.10, 20.1, 22.1, or 22.2.
 
 First, obtain a license of CPLEX and install CPLEX solver, following the
 instructions on [IBM's website](https://www.ibm.com/analytics/cplex-optimizer).

--- a/deps/build.jl
+++ b/deps/build.jl
@@ -16,6 +16,7 @@ const _CPX_VERS = [ # From oldest to most recent.
     "221", "2210", "22100",
     "2211", "22110",
     "2212", "22120",
+    "2220", "22220",
 ]
 const _BASE_ENV = "CPLEX_STUDIO_BINARIES"
 
@@ -48,14 +49,14 @@ function get_error_message_if_not_found()
 
     * 12.10
     * 20.1
-    * 22.1 22.1.1 22.1.2
+    * 22.2 22.1 22.1.1 22.1.2
 
     You must download and install one of these versions separately.
 
     You should set the `CPLEX_STUDIO_BINARIES` environment variable to point to
     the install location then try again. For example (updating the path to the
     correct location):
-    
+
     ```
     ENV["CPLEX_STUDIO_BINARIES"] = "$(default_installation_path("CPLEX_Studio221"))"
     import Pkg
@@ -80,9 +81,9 @@ function check_cplex_in_libnames(libnames)
 end
 
 function check_cplex_in_environment_variables()
-    # Find CPLEX in the CPLEX environment variables. 
+    # Find CPLEX in the CPLEX environment variables.
     libnames = String[]
-    
+
     for v in reverse(_CPX_VERS)
         name = library_name(v)
 
@@ -124,10 +125,10 @@ function check_cplex_in_default_paths()
 end
 
 function try_local_installation()
-    # Iterate through a series of places where CPLEX could be found: either 
-    # from an environment variable, in the path (directly the callable library 
-    # or the CPLEX executable), or in a default install location, in that 
-    # order. Indeed, some software packages propose a version of CPLEX in the 
+    # Iterate through a series of places where CPLEX could be found: either
+    # from an environment variable, in the path (directly the callable library
+    # or the CPLEX executable), or in a default install location, in that
+    # order. Indeed, some software packages propose a version of CPLEX in the
     # PATH that is not useable from Julia.
     for libnames in [check_cplex_in_environment_variables(), check_cplex_in_default_paths()]
         found_cplex_lib = check_cplex_in_libnames(libnames)
@@ -137,7 +138,7 @@ function try_local_installation()
             return
         end
     end
-    
+
     error(get_error_message_if_not_found())
 end
 

--- a/src/CPLEX.jl
+++ b/src/CPLEX.jl
@@ -35,28 +35,32 @@ if _CPLEX_VERSION == v"12.10.0"
 elseif _CPLEX_VERSION == v"20.1.0"
     include("gen2010/libcpx_common.jl")
     include("gen2010/libcpx_api.jl")
-elseif _CPLEX_VERSION in (v"22.1.0", v"22.1.1", v"22.1.2")
+elseif _CPLEX_VERSION in (v"22.1.0", v"22.1.1", v"22.1.2", v"22.2.0")
     include("gen2210/ctypes.jl")
     include("gen2210/libcpx_common.jl")
     include("gen2210/libcpx_api.jl")
 else
-    error("""
-You have installed version $_CPLEX_VERSION of CPLEX, which is not supported
-by CPLEX.jl. We require CPLEX version 12.10, 20.1, or 22.1.
+    error(
+        """
+        You have installed version $_CPLEX_VERSION of CPLEX, which is not supported
+        by CPLEX.jl. We require CPLEX version 12.10, 20.1, 22.1, or 22.2.
 
-After installing CPLEX, run:
+        After installing CPLEX, run:
+        ```julia
+        import Pkg
+        Pkg.rm("CPLEX")
+        Pkg.add("CPLEX")
+        ```
 
-    import Pkg
-    Pkg.rm("CPLEX")
-    Pkg.add("CPLEX")
+        Make sure you set the environment variable `CPLEX_STUDIO_BINARIES` following
+        the instructions in the CPLEX.jl README, which is available at
+        https://github.com/jump-dev/CPLEX.jl.
 
-Make sure you set the environment variable `CPLEX_STUDIO_BINARIES` following
-the instructions in the CPLEX.jl README, which is available at
-https://github.com/jump-dev/CPLEX.jl.
-
-If you have a newer version of CPLEX installed, changes may need to be made
-to the Julia code. Please open an issue at
-https://github.com/jump-dev/CPLEX.jl.""")
+        If you have a newer version of CPLEX installed, changes may need to be made
+        to the Julia code. Please open an issue at
+        https://github.com/jump-dev/CPLEX.jl.
+        """,
+    )
 end
 
 include("MOI/MOI_wrapper.jl")


### PR DESCRIPTION
Closes #465 

We don't have the version in CI, so here goes:

```
     Testing Running tests...
context_id = 2
Version identifier: 22.2.0.0 | 2026-05-04 | 5dff98e58

Multi-objective solve log . . .

Index  Priority  Blend          Objective      Nodes  Time (sec.)  DetTime (ticks)
    1         1      2   1.9050000000e+03          0         0.00             0.10
CPLEX Error  3003: Not a mixed-integer problem.
Version identifier: 22.2.0.0 | 2026-05-04 | 5dff98e58
Tried aggregator 1 time.
LP Presolve eliminated 0 rows and 1 columns.
All rows and columns eliminated.
Presolve time = 0.00 sec. (0.00 ticks)
CPLEX Error  3003: Not a mixed-integer problem.
Test Summary:          | Pass  Total     Time
MathOptInterface Tests | 4693   4693  2m26.2s
     Testing CPLEX tests passed 
```